### PR TITLE
Adding Subreport Support

### DIFF
--- a/RdlMigration.UnitTest/ConvertRDLTests.cs
+++ b/RdlMigration.UnitTest/ConvertRDLTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) 2019 Microsoft Corporation. All Rights Reserved.
+// Licensed under the MIT License (MIT)
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Xml.Linq;
+using Microsoft.PowerBI.Api.V2;
+using Microsoft.PowerBI.Api.V2.Models;
+using Microsoft.Rest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using RdlMigration.ReportServerApi;
+using static RdlMigration.ElementNameConstants;
+
+namespace RdlMigration.UnitTest
+{
+    [TestClass]
+    public class ConvertRDLTests
+    {
+        [TestMethod]
+        public void SubreportsAreDiscovered()
+        {
+            var mockApp = new Mock<ConvertRDL>();
+            var mockServer = new Mock<IReportingService2010>();
+
+            mockServer.Setup(p => p.GetItemType(It.IsAny<string>())).Returns(SoapApiConstants.Report);
+            var sut = new ConvertRDL();
+            sut.rootFolder = "/test";
+            sut.rdlFileIO = new RdlFileIO(mockServer.Object);
+            XDocument doc = XDocument.Load("../../testFiles/subreport_SubreportInBody.rdl");
+            var subreports = sut.DiscoverSubreports(doc);
+
+            Assert.AreEqual(subreports.Count, 2);
+            Assert.AreEqual(subreports[0], "/test/SimpleRectangles");
+            Assert.AreEqual(subreports[1], "/test/Burger");
+        }
+
+        [TestMethod]
+        public void InvalidPathsAreIgnored()
+        {
+            var mockApp = new Mock<ConvertRDL>();
+            var mockServer = new Mock<IReportingService2010>();
+
+            mockServer.Setup(p => p.GetItemType(It.IsAny<string>())).Returns(SoapApiConstants.Folder);
+            var sut = new ConvertRDL();
+            sut.rootFolder = "/test";
+            sut.rdlFileIO = new RdlFileIO(mockServer.Object);
+            XDocument doc = XDocument.Load("../../testFiles/subreport_SubreportInBody.rdl");
+            var subreports = sut.DiscoverSubreports(doc);
+
+            Assert.AreEqual(subreports.Count, 0);
+        }
+
+        [TestMethod]
+        public void DuplicateNamesAreIgnored()
+        {
+            var mockApp = new Mock<ConvertRDL>();
+            var mockServer = new Mock<IReportingService2010>();
+
+            mockServer.Setup(p => p.GetItemType(It.IsAny<string>())).Returns(SoapApiConstants.Report);
+            var sut = new ConvertRDL();
+            sut.rootFolder = "/test";
+            sut.rdlFileIO = new RdlFileIO(mockServer.Object);
+            sut.reportNameMap.TryAdd("SimpleRectangles", 1);
+            XDocument doc = XDocument.Load("../../testFiles/subreport_SubreportInBody.rdl");
+            var subreports = sut.DiscoverSubreports(doc);
+
+            Assert.AreEqual(subreports.Count, 1);
+            Assert.AreEqual(subreports[0], "/test/Burger");
+        }
+    }
+}

--- a/RdlMigration.UnitTest/RdlMigration.UnitTest.csproj
+++ b/RdlMigration.UnitTest/RdlMigration.UnitTest.csproj
@@ -75,6 +75,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConvertRDLTests.cs" />
     <Compile Include="FileTest.cs" />
     <Compile Include="RdlFileIOTests.cs" />
     <Compile Include="PowerBIClientWrapperTests.cs" />

--- a/RdlMigration.UnitTest/testFiles/subreport_SubreportInBody.rdl
+++ b/RdlMigration.UnitTest/testFiles/subreport_SubreportInBody.rdl
@@ -1,0 +1,140 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Report MustUnderstand="df" xmlns="http://schemas.microsoft.com/sqlserver/reporting/2016/01/reportdefinition" xmlns:rd="http://schemas.microsoft.com/SQLServer/reporting/reportdesigner" xmlns:df="http://schemas.microsoft.com/sqlserver/reporting/2016/01/reportdefinition/defaultfontfamily">
+  <df:DefaultFontFamily>Segoe UI</df:DefaultFontFamily>
+  <AutoRefresh>0</AutoRefresh>
+  <ReportSections>
+    <ReportSection>
+      <Body>
+        <ReportItems>
+          <Textbox Name="ReportTitle">
+            <CanGrow>true</CanGrow>
+            <KeepTogether>true</KeepTogether>
+            <Paragraphs>
+              <Paragraph>
+                <TextRuns>
+                  <TextRun>
+                    <Value>Main Report</Value>
+                    <Style>
+                      <FontFamily>Segoe UI Light</FontFamily>
+                      <FontSize>28pt</FontSize>
+                    </Style>
+                  </TextRun>
+                </TextRuns>
+                <Style />
+              </Paragraph>
+            </Paragraphs>
+            <rd:WatermarkTextbox>Title</rd:WatermarkTextbox>
+            <rd:DefaultName>ReportTitle</rd:DefaultName>
+            <Height>0.5in</Height>
+            <Width>5.5in</Width>
+            <Style>
+              <Border>
+                <Style>None</Style>
+              </Border>
+              <PaddingLeft>2pt</PaddingLeft>
+              <PaddingRight>2pt</PaddingRight>
+              <PaddingTop>2pt</PaddingTop>
+              <PaddingBottom>2pt</PaddingBottom>
+            </Style>
+          </Textbox>
+          <Subreport Name="Subreport1">
+            <ReportName>SimpleRectangles</ReportName>
+            <Top>0.755in</Top>
+            <Left>0.38in</Left>
+            <Height>3in</Height>
+            <Width>3in</Width>
+            <ZIndex>1</ZIndex>
+            <Style>
+              <Border>
+                <Color>LightBlue</Color>
+                <Style>Solid</Style>
+                <Width>2.5pt</Width>
+              </Border>
+            </Style>
+          </Subreport>
+          <Subreport Name="Subreport2">
+            <ReportName>Burger</ReportName>
+            <Top>0.74667in</Top>
+            <Left>3.92167in</Left>
+            <Height>3in</Height>
+            <Width>3in</Width>
+            <ZIndex>2</ZIndex>
+            <Style>
+              <Border>
+                <Color>Gold</Color>
+                <Style>Dotted</Style>
+                <Width>2.5pt</Width>
+              </Border>
+            </Style>
+          </Subreport>
+        </ReportItems>
+        <Height>4.40605in</Height>
+        <Style>
+          <Border>
+            <Style>None</Style>
+          </Border>
+        </Style>
+      </Body>
+      <Width>7.29667in</Width>
+      <Page>
+        <PageFooter>
+          <Height>0.66875in</Height>
+          <PrintOnFirstPage>true</PrintOnFirstPage>
+          <PrintOnLastPage>true</PrintOnLastPage>
+          <ReportItems>
+            <Textbox Name="ExecutionTime">
+              <CanGrow>true</CanGrow>
+              <KeepTogether>true</KeepTogether>
+              <Paragraphs>
+                <Paragraph>
+                  <TextRuns>
+                    <TextRun>
+                      <Value>=Globals!ExecutionTime</Value>
+                      <Style />
+                    </TextRun>
+                  </TextRuns>
+                  <Style>
+                    <TextAlign>Right</TextAlign>
+                  </Style>
+                </Paragraph>
+              </Paragraphs>
+              <rd:DefaultName>ExecutionTime</rd:DefaultName>
+              <Top>0.2in</Top>
+              <Left>4in</Left>
+              <Height>0.25in</Height>
+              <Width>2in</Width>
+              <Style>
+                <Border>
+                  <Style>None</Style>
+                </Border>
+                <PaddingLeft>2pt</PaddingLeft>
+                <PaddingRight>2pt</PaddingRight>
+                <PaddingTop>2pt</PaddingTop>
+                <PaddingBottom>2pt</PaddingBottom>
+              </Style>
+            </Textbox>
+          </ReportItems>
+          <Style>
+            <Border>
+              <Style>None</Style>
+            </Border>
+          </Style>
+        </PageFooter>
+        <LeftMargin>1in</LeftMargin>
+        <RightMargin>1in</RightMargin>
+        <TopMargin>1in</TopMargin>
+        <BottomMargin>1in</BottomMargin>
+        <Style />
+      </Page>
+    </ReportSection>
+  </ReportSections>
+  <ReportParametersLayout>
+    <GridLayoutDefinition>
+      <NumberOfColumns>4</NumberOfColumns>
+      <NumberOfRows>2</NumberOfRows>
+    </GridLayoutDefinition>
+  </ReportParametersLayout>
+  <rd:ReportUnitType>Inch</rd:ReportUnitType>
+  <rd:ReportServerUrl>http://rosereports/reportserver</rd:ReportServerUrl>
+  <rd:ReportID>a9287a7f-670b-4ee0-8804-125c20bd03d7</rd:ReportID>
+</Report>

--- a/RdlMigration/ConvertRDL.cs
+++ b/RdlMigration/ConvertRDL.cs
@@ -598,7 +598,7 @@ namespace RdlMigration
                 subreportPath = subreportPath.Substring(subreportPath.IndexOf('/'));   // file path from server root
                 subreportName = Path.GetFileName(subreportPath);                       // clean file name with no folder path
                 
-                if (!rdlFileIO.IsFile(subreportPath))
+                if (!rdlFileIO.IsReport(subreportPath))
                 {
                     Trace($"SUBREPORT FAIL : {subreportPath} Subreport does not exist");
                     continue;
@@ -611,7 +611,7 @@ namespace RdlMigration
                 }
                 else
                 {
-                    Trace($"SUBREPORT : {subreportPath} A report with the same file name is already in the upload queue");
+                    Trace($"CONFLICT : a file with name \"{subreportName}\" has already been uploaded ");
                 }
             }
             

--- a/RdlMigration/ConvertRDL.cs
+++ b/RdlMigration/ConvertRDL.cs
@@ -49,10 +49,6 @@ namespace RdlMigration
                 Directory.CreateDirectory("output");
             }
 
-            // subreport logic
-            // add file name array
-            // use while loop until all files are added
-
             if (!rdlFileIO.IsFolder(inputPath))
             {
                 rootFolder = Path.GetDirectoryName(inputPath).Replace("\\", "/");
@@ -589,7 +585,8 @@ namespace RdlMigration
             {
                 var subreportName = subreport.Elements().First().Value;
                 var subreportPath = Path.Combine(rootFolder, subreportName);
-                subreportPath = Path.GetFullPath(subreportPath).Replace("\\", "/").Replace("C:", ""); // TODO: how to not hard code C drive
+                subreportPath = Path.GetFullPath(subreportPath).Replace("\\", "/");
+                subreportPath = subreportPath.Substring(subreportPath.IndexOf('/'));
                 subreportName = Path.GetFileName(subreportPath);
                 
                 try
@@ -610,13 +607,8 @@ namespace RdlMigration
                 {
                     subreportPaths.Add(subreportPath);
                     reportNameMap.TryAdd(subreportName, subreportPath);
-                    // subreport.Elements().First().SetValue(subreportName);
                     Trace($"SUBREPORT : Attempting to upload subreport from {subreportPath}");
                 }
-                // else if (string.Equals(subreportPath, existingSubreportPath))
-                // {
-                //     subreport.Elements().First().SetValue(subreportName);
-                // }
                 else
                 {
                     Trace($"SUBREPORT : {subreportPath} A report with the same file name is already in the upload queue");

--- a/RdlMigration/ConvertRDL.cs
+++ b/RdlMigration/ConvertRDL.cs
@@ -24,7 +24,7 @@ namespace RdlMigration
     {
         private string rootFolder;
         private ConcurrentDictionary<string, string> reportNameMap = new ConcurrentDictionary<string, string>();
-        private PowerBIClientWrapper powerBIPortal;
+        private PowerBIClientWrapper powerBIClient;
         private RdlFileIO rdlFileIO;
         
         /// <summary>
@@ -37,7 +37,7 @@ namespace RdlMigration
         public void ConvertFolder(string urlEndPoint, string inputPath, string workspaceName, string clientID)
         {
             Trace("Starting the log-in window");
-            powerBIPortal = new PowerBIClientWrapper(workspaceName, clientID);
+            powerBIClient = new PowerBIClientWrapper(workspaceName, clientID);
             Trace("Log-in successfully, retrieving the reports...");
 
             rdlFileIO = new RdlFileIO(urlEndPoint);
@@ -55,7 +55,7 @@ namespace RdlMigration
                 var reportName = Path.GetFileName(inputPath);
                 reportNameMap.TryAdd(reportName, inputPath);
                 ConvertAndUploadReport(
-                                        powerBIPortal,
+                                        powerBIClient,
                                         rdlFileIO,
                                         inputPath);
             }
@@ -71,7 +71,7 @@ namespace RdlMigration
                     reportNameMap.TryAdd(reportName, reportPath);
                 }
                 Parallel.ForEach(reportPaths, reportPath => ConvertAndUploadReport(
-                                                                                powerBIPortal,
+                                                                                powerBIClient,
                                                                                 rdlFileIO,
                                                                                 reportPath));
             }
@@ -603,7 +603,7 @@ namespace RdlMigration
                     continue;
                 }
 
-                if (!reportNameMap.TryGetValue(subreportName, out string existingSubreportPath))
+                if (!reportNameMap.ContainsKey(subreportName))
                 {
                     subreportPaths.Add(subreportPath);
                     reportNameMap.TryAdd(subreportName, subreportPath);
@@ -616,7 +616,7 @@ namespace RdlMigration
             }
             
             Parallel.ForEach(subreportPaths, subreportPath => ConvertAndUploadReport(
-                                                                                powerBIPortal,
+                                                                                powerBIClient,
                                                                                 rdlFileIO,
                                                                                 subreportPath));
         }

--- a/RdlMigration/ConvertRDL.cs
+++ b/RdlMigration/ConvertRDL.cs
@@ -589,24 +589,15 @@ namespace RdlMigration
                 subreportPath = subreportPath.Substring(subreportPath.IndexOf('/'));
                 subreportName = Path.GetFileName(subreportPath);
                 
-                try
-                {
-                    if (rdlFileIO.IsFolder(subreportPath))
-                    {
-                        Trace($"SUBREPORT FAIL : {subreportPath} Subreport does not exist");
-                        continue;
-                    }
-                }
-                catch (Exception)
+                if (!rdlFileIO.IsFile(subreportPath))
                 {
                     Trace($"SUBREPORT FAIL : {subreportPath} Subreport does not exist");
                     continue;
                 }
 
-                if (!reportNameMap.ContainsKey(subreportName))
+                if (reportNameMap.TryAdd(subreportName, subreportPath))
                 {
                     subreportPaths.Add(subreportPath);
-                    reportNameMap.TryAdd(subreportName, subreportPath);
                     Trace($"SUBREPORT : Attempting to upload subreport from {subreportPath}");
                 }
                 else

--- a/RdlMigration/ElementNameConstants.cs
+++ b/RdlMigration/ElementNameConstants.cs
@@ -85,10 +85,10 @@ namespace RdlMigration
         public class PowerBIWrapperConstants
         {
             public const string MyWorkspace = "My Workspace";
-            public const string ResourceUrl = "https://analysis.windows-int.net/powerbi/api"; // https://analysis.windows.net/powerbi/api
+            public const string ResourceUrl = "https://analysis.windows.net/powerbi/api";
             public const string RedirectUrl = "urn:ietf:wg:oauth:2.0:oob";
-            public const string AuthorityUri = "https://login.windows-ppe.net/common/"; // https://login.windows.net/common/
-            public const string PowerBiApiUri = "https://powerbiapi.analysis-df.windows.net"; // https://api.powerbi.com
+            public const string AuthorityUri = "https://login.microsoftonline.com/common";
+            public const string PowerBiApiUri = "https://api.powerbi.com";
         }
     }
 }

--- a/RdlMigration/ElementNameConstants.cs
+++ b/RdlMigration/ElementNameConstants.cs
@@ -85,10 +85,10 @@ namespace RdlMigration
         public class PowerBIWrapperConstants
         {
             public const string MyWorkspace = "My Workspace";
-            public const string ResourceUrl = "https://analysis.windows.net/powerbi/api";
+            public const string ResourceUrl = "https://analysis.windows-int.net/powerbi/api"; // https://analysis.windows.net/powerbi/api
             public const string RedirectUrl = "urn:ietf:wg:oauth:2.0:oob";
-            public const string AuthorityUri = "https://login.microsoftonline.com/common";
-            public const string PowerBiApiUri = "https://api.powerbi.com";
+            public const string AuthorityUri = "https://login.windows-ppe.net/common/"; // https://login.windows.net/common/
+            public const string PowerBiApiUri = "https://powerbiapi.analysis-df.windows.net"; // https://api.powerbi.com
         }
     }
 }

--- a/RdlMigration/RdlFileIO.cs
+++ b/RdlMigration/RdlFileIO.cs
@@ -74,16 +74,9 @@ namespace RdlMigration
             }
         }
 
-        public bool IsFile(string itemPath)
+        public bool IsReport(string itemPath)
         {
-            if (server.GetItemType(itemPath) == SoapApiConstants.Report)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return (server.GetItemType(itemPath) == SoapApiConstants.Report);
         }
 
         /// <summary>

--- a/RdlMigration/RdlFileIO.cs
+++ b/RdlMigration/RdlFileIO.cs
@@ -74,6 +74,18 @@ namespace RdlMigration
             }
         }
 
+        public bool IsFile(string itemPath)
+        {
+            if (server.GetItemType(itemPath) == SoapApiConstants.Report)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
         /// <summary>
         /// Downloads a rdl file from report Server.
         /// </summary>


### PR DESCRIPTION
For all reports to be migrated by this tool, all their nested subreports will also me uploaded regardless of their file location. 

Reports with conflicting names - either with existing reports in the workspace or other reports in the upload queue - will not be uploaded. 

In PowerBI, the default behavior for subreport paths (defined in parent report) is to ignore all folder directories and look for and report that matches the file name within the current workspace. With this knowledge, we will not be renaming the subreport paths in the parent report.