### PR TITLE
Add mapping between dataset and name

### DIFF
--- a/RdlMigration.UnitTest/ConvertRDLTests.cs
+++ b/RdlMigration.UnitTest/ConvertRDLTests.cs
@@ -1,14 +1,7 @@
 ﻿// Copyright (c) 2019 Microsoft Corporation. All Rights Reserved.
 // Licensed under the MIT License (MIT)
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading;
 using System.Xml.Linq;
-using Microsoft.PowerBI.Api.V2;
-using Microsoft.PowerBI.Api.V2.Models;
-using Microsoft.Rest;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using RdlMigration.ReportServerApi;
@@ -22,7 +15,6 @@ namespace RdlMigration.UnitTest
         [TestMethod]
         public void SubreportsAreDiscovered()
         {
-            var mockApp = new Mock<ConvertRDL>();
             var mockServer = new Mock<IReportingService2010>();
 
             mockServer.Setup(p => p.GetItemType(It.IsAny<string>())).Returns(SoapApiConstants.Report);
@@ -40,7 +32,6 @@ namespace RdlMigration.UnitTest
         [TestMethod]
         public void InvalidPathsAreIgnored()
         {
-            var mockApp = new Mock<ConvertRDL>();
             var mockServer = new Mock<IReportingService2010>();
 
             mockServer.Setup(p => p.GetItemType(It.IsAny<string>())).Returns(SoapApiConstants.Folder);
@@ -56,7 +47,6 @@ namespace RdlMigration.UnitTest
         [TestMethod]
         public void DuplicateNamesAreIgnored()
         {
-            var mockApp = new Mock<ConvertRDL>();
             var mockServer = new Mock<IReportingService2010>();
 
             mockServer.Setup(p => p.GetItemType(It.IsAny<string>())).Returns(SoapApiConstants.Report);

--- a/RdlMigration.UnitTest/FileTest.cs
+++ b/RdlMigration.UnitTest/FileTest.cs
@@ -1,10 +1,15 @@
 ﻿// Copyright (c) 2019 Microsoft Corporation. All Rights Reserved.
 // Licensed under the MIT License (MIT)
 
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Xml.Linq;
 using System.Xml.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RdlMigration.ReportServerApi;
+using static RdlMigration.ElementNameConstants;
 
 namespace RdlMigration.UnitTest
 {
@@ -187,18 +192,118 @@ namespace RdlMigration.UnitTest
         {
             TestWithPath(downloadPath + test + ".rdl", downloadPath + test + ".rds", downloadPath + test + "_DataSets");
         }
+
         private void TestWithPath(string rdlFilePath, string dataSourcePath, string dataSetPath)
         {
             var app = new ConvertRDL();
-            var dataSources = app.ReadDataSourceFile(dataSourcePath);
-            var dataSets = app.ReadDataSet(dataSetPath);
+            var dataSources = ReadDataSourceFile(dataSourcePath);
+            var dataSets = ReadDataSet(rdlFilePath, dataSetPath);
 
-            //var dataSets = RdlFileIO.WriteDataSetContent(rdlFilePath, "aka" ,out DataSource[] a);
             Directory.CreateDirectory(outputPath);
             Directory.CreateDirectory(downloadPath);
             var file = app.ConvertFile(rdlFilePath, dataSources, dataSets, outputPath);
 
             ValidateSchema(file);
+        }
+
+        /// <summary>
+        /// Returns the list of dataset names for a datasetPath used b
+        /// </summary>
+        public Dictionary<string, List<string>> GetDataSetsMap(string rdlFilePath)
+        {
+            var result = new Dictionary<string, List<string>>();
+            XDocument doc = XDocument.Load(rdlFilePath);
+            var dataSets = doc.Descendants().Where(p => p.Name.LocalName == DataSetConstants.SharedDataSetReference);
+            foreach(var dataSet in dataSets)
+            {
+                if (!result.ContainsKey(dataSet.Value))
+                {
+                    result.Add(dataSet.Value, new List<string>());
+                }
+
+                result[dataSet.Value].Add(dataSet.Parent.Parent.Attribute("Name").Value);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Reads a datasource file and take it into DataSource object.
+        /// </summary>
+        /// <param name="filePath">The local rds File path.</param>
+        /// <returns> an array of DataSource Object.</returns>
+        public DataSource[] ReadDataSourceFile(string filePath)
+        {
+            XDocument doc = XDocument.Load(filePath);
+            var dataSources = doc.Element(DataSourceConstants.DataSources) == null ? new XElement[0] : doc.Element(DataSourceConstants.DataSources).Elements();
+            DataSource[] retDataSourceArray = new DataSource[dataSources.Count()];
+            int i = 0;
+            foreach (XElement childNode in dataSources)
+            {
+                DataSource temp = new DataSource
+                {
+                    Name = childNode.Attribute("Name").Value
+                };
+                DataSourceDefinition currDataSourceDefinition = new DataSourceDefinition
+                {
+                    Extension = childNode.Element(DataSourceConstants.Extension).Value,
+                    ConnectString = childNode.Element(DataSourceConstants.ConnectString).Value,
+                    UseOriginalConnectString = childNode.Element(DataSourceConstants.UseOriginalConnectString).Value == "True",
+                    OriginalConnectStringExpressionBased = childNode.Element(DataSourceConstants.OriginalConnectStringExpressionBased).Value == "True"
+                };
+
+                Enum.TryParse(childNode.Element(DataSourceConstants.CredentialRetrieval).Value, true, out CredentialRetrievalEnum credentialRetrieval);
+                currDataSourceDefinition.CredentialRetrieval = credentialRetrieval;
+
+                currDataSourceDefinition.Enabled = childNode.Element(DataSourceConstants.Enabled).Value == "True";
+
+                temp.Item = currDataSourceDefinition;
+
+                retDataSourceArray[i++] = temp;
+            }
+
+            return retDataSourceArray;
+        }
+
+        /// <summary>
+        ///  Reads a datasource file and take it into DataSource object.
+        /// </summary>
+        /// <param name="dirPath">The local rds File path.</param>
+        /// <returns> The Dictonary of Data Set Name and Data Set XElement.</returns>
+        private Dictionary<KeyValuePair<string, string>, XElement> ReadDataSet(string rdlLocalFilePath, string dirPath, Dictionary<string, string> dataSetNameRef = null)
+        {
+            var retMap = new Dictionary<KeyValuePair<string, string>, XElement>();
+            string[] filePaths;
+            try
+            {
+                filePaths = Directory.GetFiles(dirPath);
+            }
+            catch (Exception)
+            {
+                return retMap;
+            }
+
+            var dataSetMap = GetDataSetsMap(rdlLocalFilePath);
+            foreach (string filename in filePaths)
+            {
+                var currDataSetNode = ReadDataSetFile(filename);
+                var dataSetName = currDataSetNode.Attribute("Name").Value;
+
+                // for tests that have the same dataset referenced multiple times, we need to add
+                // to the map for each time its found.
+                foreach (var rdlDataSetName in dataSetMap[dataSetName])
+                {
+                    retMap.Add(new KeyValuePair<string, string>(rdlLocalFilePath, rdlDataSetName), currDataSetNode);
+                }
+            }
+
+            return retMap;
+        }
+
+        private XElement ReadDataSetFile(string filePath)
+        {
+            XDocument doc = XDocument.Load(filePath);
+            var dataSets = (XElement)doc.Root.FirstNode;
+            return dataSets;
         }
 
         private void ValidateSchema(string filePath)

--- a/RdlMigration/RdlMigration.csproj
+++ b/RdlMigration/RdlMigration.csproj
@@ -55,6 +55,9 @@ OpenAPI spec version: 2.0
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.5.1.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>


### PR DESCRIPTION
This PR addresses an issue when the dataset address registered inside RDL is different than the one returned by the SOAP GetItemReferences call. The server never updates the report which gets outdated. The fix in this case is to map the report path and dataset name for that report to the path returned by GetItemReferences.