### PR TITLE
Update error parsing

### DIFF
--- a/RdlMigration/ConvertRDL.cs
+++ b/RdlMigration/ConvertRDL.cs
@@ -127,7 +127,7 @@ namespace RdlMigration
                         {
                             string jsonString = returnedJsonStr.First();
                             var returnedJsonDetail = JObject.Parse(jsonString);
-                            errorMessage = returnedJsonDetail["error"]["pbi.error"]["details"][2]["detail"]["value"].Value<string>();
+                            errorMessage = returnedJsonDetail["error"]?["code"]?.Value<string>() ?? jsonString;
                             Trace($"FAILED TO UPLOAD :  {reportName} RequestId:{requestId} {errorMessage}");
                         }
                     }


### PR DESCRIPTION
In some cases the response payload is not as expected. Updating to just trace the error code, and if that is not present, the entire json response.